### PR TITLE
Fixed URL encoding error with &amp; separator

### DIFF
--- a/Hippy.php
+++ b/Hippy.php
@@ -284,7 +284,7 @@ class Hippy {
         $args['format']  = 'json';
         $args['message'] = $msg;
         
-        $this->endpoint_url .= '?'.http_build_query($args);
+        $this->endpoint_url .= '?'.http_build_query($args, '', '&');
         
         //Make request using cURL
         $response = $this->makeRequest($this->endpoint_url);


### PR DESCRIPTION
As of PHP 5.3, many PHP installs are defaulting to using &amp;amp; for arg_separator.output instead of &.

This causes Hippy to improperly encode URLs with http_build_query. Fixed this by explicitly defining the separator as '&' instead of relying on PHP's configured default.
