### PR TITLE
Fixes "syntax error, unexpected ','"

### DIFF
--- a/Hippy.php
+++ b/Hippy.php
@@ -268,7 +268,7 @@ class Hippy {
 		}
 		else
 		{
-			foreach($instance->queue, $msg)
+			foreach($instance->queue as $msg)
 			{
 				$instance->send($msg);
 			}


### PR DESCRIPTION
Any script invocation that includes the ::speak() call will cause this error due to an incorrect foreach statement.
