### PR TITLE
simple typo fix for defined BACKGROUND_YELLOW

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ Usage
 $transport = new rcrowe\Hippy\Transport\Guzzle($token, $room, $from);
 $hippy = new rcrowe\Hippy\Client($transport);
 
-$message = new rcrowe\Hippy\Message(true, rcrowe\Hippy\Message\Message::BACKGROUND_YELLOW);
+$message = new rcrowe\Hippy\Message(true, rcrowe\Hippy\Message::BACKGROUND_YELLOW);
 $message->setText('test');
 
 $hippy->send($message);


### PR DESCRIPTION
Hey Rob, super simple typo on readme, thanks for the great work.  Cheers, Chris
