### PR TITLE
Allow for newer Guzzle versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "type": "library",
     "require": {
         "php": ">=5.3.2",
-        "guzzle/guzzle": "~3.2.0"
+        "guzzle/guzzle": ">=3.2.0,<3.8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "*",


### PR DESCRIPTION
I had some major issues integrating your library today because you are using a very out of date Guzzle.  The only version of AWS's library that worked with this year old Guzzle version was out of date and missing some crucial methods.  I didn't see any [forwards compatibility issues](https://github.com/guzzle/guzzle/releases) when allowing for a year range of Guzzle libraries.
