### PR TITLE
Add support for api v2 with same interface

### DIFF
--- a/src/rcrowe/Hippy/Facade.php
+++ b/src/rcrowe/Hippy/Facade.php
@@ -10,7 +10,7 @@
 
 namespace rcrowe\Hippy;
 
-use rcrowe\Hippy\Transport\Guzzle;
+use rcrowe\Hippy\Transport\APIVersion1;
 use rcrowe\Hippy\Client;
 use rcrowe\Hippy\Queue;
 use rcrowe\Hippy\Message;
@@ -42,7 +42,7 @@ class Facade
     public static function init($token, $room, $from, $transport = null)
     {
         if ($transport === null) {
-            $transport = new Guzzle($token, $room, $from);
+            $transport = new APIVersion1($token, $room, $from);
         }
 
         static::$client = new Client($transport);

--- a/src/rcrowe/Hippy/Transport/APIVersion1.php
+++ b/src/rcrowe/Hippy/Transport/APIVersion1.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * PHP client for HipChat. Designed for incidental notifications from an application.
+ *
+ * @author Iñaki Abete <inakiabt@gmail.com>
+ * @copyright Copyright (c) 2015, Iñaki Abete.
+ * @license MIT
+ */
+
+namespace rcrowe\Hippy\Transport;
+
+use InvalidArgumentException;
+use rcrowe\Hippy\Message\MessageInterface;
+use rcrowe\Hippy\Transport\Guzzle;
+use Guzzle\Http\Client as Http;
+use Guzzle\Http\ClientInterface as HttpInterface;
+
+/**
+ * Uses Guzzle to send the message to Hipchat. Uses cURL.
+ */
+class APIVersion1 extends Guzzle
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected $headers = array(
+        'Content-type' => 'application/x-www-form-urlencoded'
+    );
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($token, $room, $from, $endpoint = 'https://api.hipchat.com/v1/')
+    {
+        parent::__construct($token, $room, $from, $endpoint);
+    }
+
+    /**
+     * Uri of the request URL to the Hipchat API.
+     *
+     * @return string
+     */
+    protected function getUri()
+    {
+        return 'rooms/message?format=json&auth_token='.$this->getToken();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function buildData(MessageInterface $message)
+    {
+        // Build up the data we are sending to Hipchat
+        return http_build_query(array(
+            'room_id'        => $this->getRoom(),
+            'from'           => $this->getFrom(),
+            'message'        => $message->getMessage(),
+            'message_format' => $message->getMessageFormat(),
+            'notify'         => $message->getNotification(),
+            'color'          => $message->getBackgroundColor(),
+            'format'         => 'json'
+        ), '', '&');
+    }
+}

--- a/src/rcrowe/Hippy/Transport/APIVersion2.php
+++ b/src/rcrowe/Hippy/Transport/APIVersion2.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * PHP client for HipChat. Designed for incidental notifications from an application.
+ *
+ * @author Iñaki Abete <inakiabt@gmail.com>
+ * @copyright Copyright (c) 2015, Iñaki Abete.
+ * @license MIT
+ */
+
+namespace rcrowe\Hippy\Transport;
+
+use InvalidArgumentException;
+use rcrowe\Hippy\Message\MessageInterface;
+use rcrowe\Hippy\Transport\Guzzle;
+use Guzzle\Http\Client as Http;
+use Guzzle\Http\ClientInterface as HttpInterface;
+
+/**
+ * Uses Guzzle to send the message to Hipchat. Uses cURL.
+ */
+class APIVersion2 extends Guzzle
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct($token, $room, $from, $endpoint = 'https://api.hipchat.com/v2/')
+    {
+        parent::__construct($token, $room, $from, $endpoint);
+    }
+
+    /**
+     * Uri of the request URL to the Hipchat API.
+     *
+     * @return string
+     */
+    protected function getUri()
+    {
+        return 'room/'.$this->getRoom().'/notification?auth_token='.$this->getToken();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function buildData(MessageInterface $message)
+    {
+        // Build up the data we are sending to Hipchat
+        return json_encode(array(
+            'message'        => $message->getMessage(),
+            'message_format' => $message->getMessageFormat(),
+            'notify'         => $message->getNotification(),
+            'color'          => $message->getBackgroundColor()
+        ));
+    }
+}

--- a/tests/client/APIVersion1BasicTest.php
+++ b/tests/client/APIVersion1BasicTest.php
@@ -3,9 +3,9 @@
 namespace rcrowe\Hippy\Tests\Client;
 
 use rcrowe\Hippy\Client as Hippy;
-use rcrowe\Hippy\Transport\Guzzle as Transport;
+use rcrowe\Hippy\Transport\APIVersion1 as Transport;
 
-class BasicTest extends \PHPUnit_Framework_TestCase
+class APIVersion1BasicTest extends \PHPUnit_Framework_TestCase
 {
     public function testToken()
     {
@@ -50,7 +50,7 @@ class BasicTest extends \PHPUnit_Framework_TestCase
     {
         $transport = new Transport(null, null, null);
         $hippy = new Hippy($transport);
-        $this->assertEquals(get_class($hippy->getTransport()), 'rcrowe\Hippy\Transport\Guzzle');
+        $this->assertEquals(get_class($hippy->getTransport()), 'rcrowe\Hippy\Transport\APIVersion1');
 
         $transport = new Transport(null, null, null);
         $transport->helloWorld = 'egg';

--- a/tests/client/APIVersion1SendTest.php
+++ b/tests/client/APIVersion1SendTest.php
@@ -4,11 +4,11 @@ namespace rcrowe\Hippy\Tests\Client;
 
 use Mockery as m;
 use rcrowe\Hippy\Client as Hippy;
-use rcrowe\Hippy\Transport\Guzzle;
+use rcrowe\Hippy\Transport\APIVersion1;
 use rcrowe\Hippy\Message;
 use rcrowe\Hippy\Queue;
 
-class SendTest extends \PHPUnit_Framework_TestCase
+class APIVersion1SendTest extends \PHPUnit_Framework_TestCase
 {
     public function tearDown()
     {
@@ -23,7 +23,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
         $http = m::mock('Guzzle\Http\Client');
         $http->shouldReceive('post')->andReturn($entity)->once();
 
-        $transport = new Guzzle('123', 'cog', 'vivalacrowe');
+        $transport = new APIVersion1('123', 'cog', 'vivalacrowe');
         $transport->setHttp($http);
         $guzzle = new Hippy($transport);
 
@@ -40,7 +40,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
         $http = m::mock('Guzzle\Http\Client');
         $http->shouldReceive('post')->andReturn($entity)->twice();
 
-        $transport = new Guzzle('123', 'cog', 'vivalacrowe');
+        $transport = new APIVersion1('123', 'cog', 'vivalacrowe');
         $transport->setHttp($http);
         $hippy = new Hippy($transport);
 

--- a/tests/client/APIVersion2BasicTest.php
+++ b/tests/client/APIVersion2BasicTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace rcrowe\Hippy\Tests\Client;
+
+use rcrowe\Hippy\Client as Hippy;
+use rcrowe\Hippy\Transport\APIVersion2 as Transport;
+
+class APIVersion2BasicTest extends \PHPUnit_Framework_TestCase
+{
+    public function testToken()
+    {
+        $transport = new Transport(null, null, null);
+        $hippy     = new Hippy($transport);
+        $this->assertNull($hippy->getToken());
+        $hippy->setToken('12345');
+        $this->assertEquals($hippy->getToken(), '12345');
+
+        $transport = new Transport('54321', null, null);
+        $hippy     = new Hippy($transport);
+        $this->assertEquals($hippy->getToken(), '54321');
+    }
+
+    public function testRoom()
+    {
+        $transport = new Transport(null, null, null);
+        $hippy     = new Hippy($transport);
+        $this->assertNull($hippy->getRoom());
+        $hippy->setRoom('general');
+        $this->assertEquals($hippy->getRoom(), 'general');
+
+        $transport = new Transport(null, 'chilli', null);
+        $hippy     = new Hippy($transport);
+        $this->assertEquals($hippy->getRoom(), 'chilli');
+    }
+
+    public function testFrom()
+    {
+        $transport = new Transport(null, null, null);
+        $hippy     = new Hippy($transport);
+        $this->assertNull($hippy->getFrom());
+        $hippy->setFrom('rcrowe');
+        $this->assertEquals($hippy->getFrom(), 'rcrowe');
+
+        $transport = new Transport(null, null, 'vivalacrowe');
+        $hippy = new Hippy($transport);
+        $this->assertEquals($hippy->getFrom(), 'vivalacrowe');
+    }
+
+    public function testTransport()
+    {
+        $transport = new Transport(null, null, null);
+        $hippy = new Hippy($transport);
+        $this->assertEquals(get_class($hippy->getTransport()), 'rcrowe\Hippy\Transport\APIVersion2');
+
+        $transport = new Transport(null, null, null);
+        $transport->helloWorld = 'egg';
+        $hippy = new Hippy($transport);
+        $hippy->setTransport($transport);
+
+        $this->assertEquals($hippy->getTransport()->helloWorld, 'egg');
+    }
+}

--- a/tests/client/APIVersion2SendTest.php
+++ b/tests/client/APIVersion2SendTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace rcrowe\Hippy\Tests\Client;
+
+use Mockery as m;
+use rcrowe\Hippy\Client as Hippy;
+use rcrowe\Hippy\Transport\APIVersion2;
+use rcrowe\Hippy\Message;
+use rcrowe\Hippy\Queue;
+
+class APIVersion2SendTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testSingleMessage()
+    {
+        $entity = m::mock('Guzzle\Http\Message\EntityEnclosingRequest');
+        $entity->shouldReceive('send')->once();
+
+        $http = m::mock('Guzzle\Http\Client');
+        $http->shouldReceive('post')->andReturn($entity)->once();
+
+        $transport = new APIVersion2('123', 'cog', 'vivalacrowe');
+        $transport->setHttp($http);
+        $guzzle = new Hippy($transport);
+
+        $message = new Message(true, 'red');
+
+        $guzzle->send($message);
+    }
+
+    public function testQueuedMessages()
+    {
+        $entity = m::mock('Guzzle\Http\Message\EntityEnclosingRequest');
+        $entity->shouldReceive('send')->twice();
+
+        $http = m::mock('Guzzle\Http\Client');
+        $http->shouldReceive('post')->andReturn($entity)->twice();
+
+        $transport = new APIVersion2('123', 'cog', 'vivalacrowe');
+        $transport->setHttp($http);
+        $hippy = new Hippy($transport);
+
+        $queue = new Queue;
+        $queue->add(new Message(true, 'red'));
+        $queue->add(new Message(false, 'random'));
+
+        $hippy->send($queue);
+    }
+}

--- a/tests/facade/InitTest.php
+++ b/tests/facade/InitTest.php
@@ -3,7 +3,7 @@
 namespace rcrowe\Hippy\Tests\Facade;
 
 use rcrowe\Hippy\Facade as Hippy;
-use rcrowe\Hippy\Transport\Guzzle;
+use rcrowe\Hippy\Transport\APIVersion1;
 use ReflectionClass;
 
 class InitTest extends \PHPUnit_Framework_TestCase
@@ -24,7 +24,7 @@ class InitTest extends \PHPUnit_Framework_TestCase
 
     public function testCustomTransportInit()
     {
-        $guzzle = new Guzzle('54321', 'cog', 'vivalacrowe');
+        $guzzle = new APIVersion1('54321', 'cog', 'vivalacrowe');
         Hippy::init('123', 'hippy', 'Rob', $guzzle);
 
         list($client, $queue) = $this->getObjects();

--- a/tests/facade/MessageTest.php
+++ b/tests/facade/MessageTest.php
@@ -3,7 +3,7 @@
 namespace rcrowe\Hippy\Tests\Facade;
 
 use rcrowe\Hippy\Facade as Hippy;
-use rcrowe\Hippy\Transport\Guzzle;
+use rcrowe\Hippy\Transport\APIVersion1;
 use Mockery as m;
 use ReflectionClass;
 
@@ -86,7 +86,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             http_build_query($data)
         )->andReturn($entity)->once();
 
-        $transport = new Guzzle('123', 'egg', 'spoon');
+        $transport = new APIVersion1('123', 'egg', 'spoon');
         $transport->setHttp($http);
 
         Hippy::init(null, null, null, $transport);
@@ -116,7 +116,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
             http_build_query($data)
         )->andReturn($entity)->once();
 
-        $transport = new Guzzle('123', 'egg', 'spoon');
+        $transport = new APIVersion1('123', 'egg', 'spoon');
         $transport->setHttp($http);
 
         Hippy::init(null, null, null, $transport);
@@ -160,7 +160,7 @@ class MessageTest extends \PHPUnit_Framework_TestCase
         $http = m::mock('Guzzle\Http\Client');
         $http->shouldReceive('post')->andReturn($entity)->times(3);
 
-        $transport = new Guzzle('123', 'egg', 'spoon');
+        $transport = new APIVersion1('123', 'egg', 'spoon');
         $transport->setHttp($http);
 
         Hippy::init(null, null, null, $transport);

--- a/tests/transport/APIVersion1BasicTest.php
+++ b/tests/transport/APIVersion1BasicTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace rcrowe\Hippy\Tests\Transport;
+
+use rcrowe\Hippy\Transport\APIVersion1;
+use Guzzle\Http\Client as Http;
+use ReflectionMethod;
+
+class APIVersion1BasicTest extends \PHPUnit_Framework_TestCase
+{
+    public function testDefaultInstance()
+    {
+        $guzzle = new APIVersion1('123', 'egg', 'vivalacrowe');
+
+        $this->assertTrue(is_a($guzzle, 'rcrowe\Hippy\Transport\TransportInterface'));
+        $this->assertEquals($guzzle->getToken(), '123');
+        $this->assertEquals($guzzle->getRoom(), 'egg');
+        $this->assertEquals($guzzle->getFrom(), 'vivalacrowe');
+        $this->assertEquals($guzzle->getEndpoint(), 'https://api.hipchat.com/v1/');
+        $this->assertTrue(is_a($guzzle->getHttp(), 'Guzzle\Http\Client'));
+        $this->assertEquals($guzzle->getHttp()->getBaseUrl(), 'https://api.hipchat.com/v1/');
+
+        $headers = $guzzle->getHeaders();
+        $this->assertEquals(count($headers), 1);
+        $this->assertEquals($headers['Content-type'], 'application/x-www-form-urlencoded');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testBadEndpoint()
+    {
+        $guzzle = new APIVersion1('123', 'egg', 'vivalacrowe', 'hello');
+    }
+
+    public function testSetEndpoint()
+    {
+        $guzzle = new APIVersion1('123', 'egg', 'vivalacrowe');
+        $guzzle->setEndpoint('https://api.hipchat.com/v23890490234/');
+
+        $this->assertEquals($guzzle->getEndpoint(), 'https://api.hipchat.com/v23890490234/');
+    }
+
+    public function testSetHeaders()
+    {
+        $guzzle = new APIVersion1(null, null, null);
+        $guzzle->setHeaders(array('egg' => 'spoon'));
+
+        $headers = $guzzle->getHeaders();
+        $this->assertEquals(count($headers), 1);
+        $this->assertEquals($headers['egg'], 'spoon');
+    }
+
+    public function testSetHttp()
+    {
+        $guzzle = new APIVersion1(null, null, null);
+        $guzzle->setHttp(new Http('https://api.cogpowered.com/v1/'));
+
+        $this->assertEquals($guzzle->getHttp()->getBaseUrl(), 'https://api.cogpowered.com/v1/');
+    }
+
+    public function testGetUri()
+    {
+        $guzzle = new APIVersion1('51423', null, null);
+
+        $method = new ReflectionMethod('rcrowe\Hippy\Transport\APIVersion1', 'getUri');
+        $method->setAccessible(true);
+
+        $this->assertEquals($method->invoke($guzzle), 'rooms/message?format=json&auth_token=51423');
+    }
+}

--- a/tests/transport/APIVersion1SendTest.php
+++ b/tests/transport/APIVersion1SendTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace rcrowe\Hippy\Tests\Transport;
+
+use Mockery as m;
+use rcrowe\Hippy\Transport\APIVersion1;
+use rcrowe\Hippy\Message;
+use InvalidArgumentException;
+use Exception;
+
+class APIVersion1SendTest extends \PHPUnit_Framework_TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testNoTokenSet()
+    {
+        $guzzle  = new APIVersion1(null, null, null);
+        $message = new Message;
+
+        try {
+            $guzzle->send($message);
+            $this->assertFalse(true);
+        } catch (InvalidArgumentException $ex) {
+            $this->assertEquals($ex->getMessage(), 'Invalid `token`');
+        } catch (Exception $ex) {
+            $this->assertFalse(true);
+        }
+    }
+
+    public function testNoRoomSet()
+    {
+        $guzzle  = new APIVersion1('123', null, null);
+        $message = new Message;
+
+        try {
+            $guzzle->send($message);
+            $this->assertFalse(true);
+        } catch (InvalidArgumentException $ex) {
+            $this->assertEquals($ex->getMessage(), 'Invalid `room`');
+        } catch (Exception $ex) {
+            $this->assertFalse(true);
+        }
+    }
+
+    public function testNoFromSet()
+    {
+        $guzzle  = new APIVersion1('123', 'cog', null);
+        $message = new Message;
+
+        try {
+            $guzzle->send($message);
+            $this->assertFalse(true);
+        } catch (InvalidArgumentException $ex) {
+            $this->assertEquals($ex->getMessage(), 'Invalid `from`');
+        } catch (Exception $ex) {
+            $this->assertFalse(true);
+        }
+    }
+
+    public function testPost()
+    {
+        $guzzle  = new APIVersion1('123', 'cog', 'vivalacrowe');
+        $message = new Message(true, 'green');
+
+        $entity = m::mock('Guzzle\Http\Message\EntityEnclosingRequest');
+        $entity->shouldReceive('send')->once();
+
+        // Build up the data we are sending to Hipchat
+        $data = array(
+            'room_id'        => $guzzle->getRoom(),
+            'from'           => $guzzle->getFrom(),
+            'message'        => $message->getMessage(),
+            'message_format' => $message->getMessageFormat(),
+            'notify'         => $message->getNotification(),
+            'color'          => $message->getBackgroundColor(),
+            'format'         => 'json',
+        );
+
+        $http = m::mock('Guzzle\Http\Client');
+        $http->shouldReceive('post')->with(
+            'rooms/message?format=json&auth_token=123',
+            array('Content-type' => 'application/x-www-form-urlencoded'),
+            http_build_query($data)
+        )->andReturn($entity)->once();
+
+        $guzzle->setHttp($http);
+        $guzzle->send($message);
+    }
+}

--- a/tests/transport/APIVersion2BasicTest.php
+++ b/tests/transport/APIVersion2BasicTest.php
@@ -2,27 +2,27 @@
 
 namespace rcrowe\Hippy\Tests\Transport;
 
-use rcrowe\Hippy\Transport\Guzzle;
+use rcrowe\Hippy\Transport\APIVersion2;
 use Guzzle\Http\Client as Http;
 use ReflectionMethod;
 
-class GuzzleBasicTest extends \PHPUnit_Framework_TestCase
+class APIVersion2BasicTest extends \PHPUnit_Framework_TestCase
 {
     public function testDefaultInstance()
     {
-        $guzzle = new Guzzle('123', 'egg', 'vivalacrowe');
+        $guzzle = new APIVersion2('123', 'egg', 'vivalacrowe');
 
         $this->assertTrue(is_a($guzzle, 'rcrowe\Hippy\Transport\TransportInterface'));
         $this->assertEquals($guzzle->getToken(), '123');
         $this->assertEquals($guzzle->getRoom(), 'egg');
         $this->assertEquals($guzzle->getFrom(), 'vivalacrowe');
-        $this->assertEquals($guzzle->getEndpoint(), 'https://api.hipchat.com/v1/');
+        $this->assertEquals($guzzle->getEndpoint(), 'https://api.hipchat.com/v2/');
         $this->assertTrue(is_a($guzzle->getHttp(), 'Guzzle\Http\Client'));
-        $this->assertEquals($guzzle->getHttp()->getBaseUrl(), 'https://api.hipchat.com/v1/');
+        $this->assertEquals($guzzle->getHttp()->getBaseUrl(), 'https://api.hipchat.com/v2/');
 
         $headers = $guzzle->getHeaders();
         $this->assertEquals(count($headers), 1);
-        $this->assertEquals($headers['Content-type'], 'application/x-www-form-urlencoded');
+        $this->assertEquals($headers['Content-type'], 'application/json');
     }
 
     /**
@@ -30,12 +30,12 @@ class GuzzleBasicTest extends \PHPUnit_Framework_TestCase
      */
     public function testBadEndpoint()
     {
-        $guzzle = new Guzzle('123', 'egg', 'vivalacrowe', 'hello');
+        $guzzle = new APIVersion2('123', 'egg', 'vivalacrowe', 'hello');
     }
 
     public function testSetEndpoint()
     {
-        $guzzle = new Guzzle('123', 'egg', 'vivalacrowe');
+        $guzzle = new APIVersion2('123', 'egg', 'vivalacrowe');
         $guzzle->setEndpoint('https://api.hipchat.com/v23890490234/');
 
         $this->assertEquals($guzzle->getEndpoint(), 'https://api.hipchat.com/v23890490234/');
@@ -43,7 +43,7 @@ class GuzzleBasicTest extends \PHPUnit_Framework_TestCase
 
     public function testSetHeaders()
     {
-        $guzzle = new Guzzle(null, null, null);
+        $guzzle = new APIVersion2(null, null, null);
         $guzzle->setHeaders(array('egg' => 'spoon'));
 
         $headers = $guzzle->getHeaders();
@@ -53,7 +53,7 @@ class GuzzleBasicTest extends \PHPUnit_Framework_TestCase
 
     public function testSetHttp()
     {
-        $guzzle = new Guzzle(null, null, null);
+        $guzzle = new APIVersion2(null, null, null);
         $guzzle->setHttp(new Http('https://api.cogpowered.com/v1/'));
 
         $this->assertEquals($guzzle->getHttp()->getBaseUrl(), 'https://api.cogpowered.com/v1/');
@@ -61,11 +61,11 @@ class GuzzleBasicTest extends \PHPUnit_Framework_TestCase
 
     public function testGetUri()
     {
-        $guzzle = new Guzzle('51423', null, null);
+        $guzzle = new APIVersion2('51423', 'room123', null);
 
-        $method = new ReflectionMethod('rcrowe\Hippy\Transport\Guzzle', 'getUri');
+        $method = new ReflectionMethod('rcrowe\Hippy\Transport\APIVersion2', 'getUri');
         $method->setAccessible(true);
 
-        $this->assertEquals($method->invoke($guzzle), 'rooms/message?format=json&auth_token=51423');
+        $this->assertEquals($method->invoke($guzzle), 'room/room123/notification?auth_token=51423');
     }
 }

--- a/tests/transport/APIVersion2SendTest.php
+++ b/tests/transport/APIVersion2SendTest.php
@@ -3,12 +3,12 @@
 namespace rcrowe\Hippy\Tests\Transport;
 
 use Mockery as m;
-use rcrowe\Hippy\Transport\Guzzle;
+use rcrowe\Hippy\Transport\APIVersion2;
 use rcrowe\Hippy\Message;
 use InvalidArgumentException;
 use Exception;
 
-class GuzzleSendTest extends \PHPUnit_Framework_TestCase
+class APIVersion2SendTest extends \PHPUnit_Framework_TestCase
 {
     public function tearDown()
     {
@@ -17,7 +17,7 @@ class GuzzleSendTest extends \PHPUnit_Framework_TestCase
 
     public function testNoTokenSet()
     {
-        $guzzle  = new Guzzle(null, null, null);
+        $guzzle  = new APIVersion2(null, null, null);
         $message = new Message;
 
         try {
@@ -32,7 +32,7 @@ class GuzzleSendTest extends \PHPUnit_Framework_TestCase
 
     public function testNoRoomSet()
     {
-        $guzzle  = new Guzzle('123', null, null);
+        $guzzle  = new APIVersion2('123', null, null);
         $message = new Message;
 
         try {
@@ -47,7 +47,7 @@ class GuzzleSendTest extends \PHPUnit_Framework_TestCase
 
     public function testNoFromSet()
     {
-        $guzzle  = new Guzzle('123', 'cog', null);
+        $guzzle  = new APIVersion2('123', 'cog', null);
         $message = new Message;
 
         try {
@@ -62,7 +62,7 @@ class GuzzleSendTest extends \PHPUnit_Framework_TestCase
 
     public function testPost()
     {
-        $guzzle  = new Guzzle('123', 'cog', 'vivalacrowe');
+        $guzzle  = new APIVersion2('123', 'cog', 'vivalacrowe');
         $message = new Message(true, 'green');
 
         $entity = m::mock('Guzzle\Http\Message\EntityEnclosingRequest');
@@ -70,20 +70,17 @@ class GuzzleSendTest extends \PHPUnit_Framework_TestCase
 
         // Build up the data we are sending to Hipchat
         $data = array(
-            'room_id'        => $guzzle->getRoom(),
-            'from'           => $guzzle->getFrom(),
             'message'        => $message->getMessage(),
             'message_format' => $message->getMessageFormat(),
             'notify'         => $message->getNotification(),
-            'color'          => $message->getBackgroundColor(),
-            'format'         => 'json',
+            'color'          => $message->getBackgroundColor()
         );
 
         $http = m::mock('Guzzle\Http\Client');
         $http->shouldReceive('post')->with(
-            'rooms/message?format=json&auth_token=123',
-            array('Content-type' => 'application/x-www-form-urlencoded'),
-            http_build_query($data)
+            'room/cog/notification?auth_token=123',
+            array('Content-type' => 'application/json'),
+            json_encode($data)
         )->andReturn($entity)->once();
 
         $guzzle->setHttp($http);


### PR DESCRIPTION
As default, it uses v1 as always:

``` php
    Hippy::init('123', 'hippy', 'Rob');

    Hippy::add('test 1');
    Hippy::addHtml('test 2');
    Hippy::add('test 3');

    Hippy::go();
```

Now, you can use v2 as a new Transport:

``` php
    $v2 = new rcrowe\Hippy\Transport\APIVersion2('54321', 'cog', 'vivalacrowe');

    Hippy::init('123', 'hippy', 'Rob', $v2);

    Hippy::add('test 1');
    Hippy::addHtml('test 2');
    Hippy::add('test 3');

    Hippy::go();
```
